### PR TITLE
Update TinyPilot's PicoShare instance to 1.4.1

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -17,7 +17,7 @@ processes = []
   auto_rollback = true
 
 [build]
-  image = "mtlynch/picoshare:1.4.0"
+  image = "mtlynch/picoshare:1.4.1"
 
 [mounts]
 source="pico_data"


### PR DESCRIPTION
Resolves #12

This change upgrades TinyPilot’s PicoShare instance to version 1.4.1. It does this by bumping the version specified under `build.image`, which, when merged into master, will cause CircleCI to deploy the new version.